### PR TITLE
HP-598 | change link to display inline block

### DIFF
--- a/angular-fe/src/app/_assets/links/links.styles.scss
+++ b/angular-fe/src/app/_assets/links/links.styles.scss
@@ -1,30 +1,25 @@
-::ng-deep{
-  .links{
+:host{
+  display: block;
+  ul, li {
     display: block;
-    ul, li{
-      display: inline;
-      list-style: none;
-      padding: 0;
-      margin: 0;
-      a{
-        display: block;
-        margin-bottom:15px;
-      }
-      icon{
-        display: inline-block;
-        margin-top: -0.3125rem;
-        margin-right: 0.4375rem;
-        vertical-align: middle;
-        .icon:before{
-          font-size: 1.25rem;
-        }
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    a {
+      display: inline-block;
+      margin-bottom:15px;
+    }
+    icon{
+      display: inline-block;
+      margin-top: -0.3125rem;
+      margin-right: 0.4375rem;
+      vertical-align: middle;
+      .icon:before{
+        font-size: 1.25rem;
       }
     }
-    li:last-child a{
-      margin-bottom: 0;
-    }
-    // &+.links{
-    //   margin-top:1.1rem;
-    // }
+  }
+  li:last-child a {
+    margin-bottom: 0;
   }
 }


### PR DESCRIPTION
as a bonus, I fixed an undocumented issue where coming from a view that had these links to a page with a footer, the footer links would no longer have a margin. you're welcome. We should definitely not be using `::ng-deep` in this fashion.