### PR TITLE
HP-570 Fixing interface mismatch

### DIFF
--- a/angular-fe/src/app/_assets/formItem/formItem.component.ts
+++ b/angular-fe/src/app/_assets/formItem/formItem.component.ts
@@ -43,6 +43,11 @@ export interface FormItemOption {
   value: string;
 }
 
+interface CustomKeyboardEvent extends KeyboardEventInit {
+  keyCode: number;
+  which: number;
+}
+
 @Component({
   selector: 'formItem',
   templateUrl: 'formItem.template.html',
@@ -145,24 +150,24 @@ export class FormItemComponent implements ControlValueAccessor, OnInit, OnChange
   }
 
   keydownEvent(e) {
-     
-    if (e.code  === 'Enter' ){
+    if (e.code  === 'Enter') {
       return false;
     }
 
-    if (e.code === "Space") {
-      const keyboardEvent = new KeyboardEvent('keydown', {
-          code: 'Enter',
-          key: 'Enter',
-          keyCode: 13,
-          which: 13, 
-          view: window,
-          bubbles: true
-      });
+    if (e.code === 'Space') {
+      const event: CustomKeyboardEvent = {
+        code: 'Enter',
+        key: 'Enter',
+        keyCode: 13,
+        which: 13,
+        view: window,
+        bubbles: true,
+      };
+      const keyboardEvent = new KeyboardEvent('keydown', event);
 
-      if(this.ngSelect) {
+      if (this.ngSelect) {
         e.preventDefault();
-        this.ngSelect.handleKeyCode(keyboardEvent)
+        this.ngSelect.handleKeyCode(keyboardEvent);
       }
     }
   }


### PR DESCRIPTION
Build had the following error, fixed it myself this time: Good practice to try "npm run build-dev" if extending, using or creating new interfaces.

ERROR in src/app/_assets/formItem/formItem.component.ts:157:11 - error TS2345: Argument of type '{ code: string; key: string; keyCode: number; which: number; view: Window & typeof globalThis; bubbles: true; }' is not assignable to parameter of type 'KeyboardEventInit'.

Object literal may only specify known properties, and 'keyCode' does not exist in type 'KeyboardEventInit'.

keyCode: 13,

