### PR TITLE
HP-1007 - fix

### DIFF
--- a/angular-fe/src/app/_assets/sidebar/helpers/sidebar.ts
+++ b/angular-fe/src/app/_assets/sidebar/helpers/sidebar.ts
@@ -91,13 +91,12 @@ export const parseInfosystemData = (inputData) => {
 export const parseProfessionData = (inputData, translate) => {
   let mappedData = inputData;
   try {
-    let searchParams = {
-      open_admission: true,
+		let searchParams = {
 			iscedf_detailed: [],
 			iscedf_narrow: [],
 			iscedf_broad: [],
 			level: [],
-    };
+		};
 
 		// õppimisvõimaluste filtrite kogumine AMETIALA puhul
     try {
@@ -146,7 +145,13 @@ export const parseProfessionData = (inputData, translate) => {
 			});
 		} catch (err) {	}
 
-		if (Object.keys(searchParams).length > 1) {
+		Object.keys(searchParams).forEach(key => {
+			if (Array.isArray(searchParams[key]) && searchParams[key].length === 0) {
+				delete searchParams[key];
+			}
+		});
+
+		if (Object.keys(searchParams).length > 0) {
       mappedData['fieldLearningOpportunities'] = [
         {
           title: translate.get('professions.go_to_subjects'),

--- a/angular-fe/src/app/_assets/sidebar/helpers/sidebar.ts
+++ b/angular-fe/src/app/_assets/sidebar/helpers/sidebar.ts
@@ -97,7 +97,6 @@ export const parseProfessionData = (inputData, translate) => {
 			iscedf_narrow: [],
 			iscedf_broad: [],
 			level: [],
-
     };
 
 		// õppimisvõimaluste filtrite kogumine AMETIALA puhul

--- a/angular-fe/src/app/_assets/sidebar/sidebar.component.ts
+++ b/angular-fe/src/app/_assets/sidebar/sidebar.component.ts
@@ -127,7 +127,7 @@ export class SidebarComponent implements OnInit, OnChanges {
   ) {
     if (route.snapshot?.data?.type) {
       this.type = route.snapshot.data.type;
-    }
+		}
   }
 
   @HostBinding('class') get hostClasses(): string {


### PR DESCRIPTION
Kui ei ole parameetreid otsingu jaoks, siis ei kuvata bloki "Õppimisvõimalused"

Kustutatud parameeter open_admission: true, mis võimaldas otsida ainult avatud õppekavaga õppimisvõimalusi.